### PR TITLE
Codegen the sync variants of functions based off the async variants

### DIFF
--- a/django/db/backends/base/base.py
+++ b/django/db/backends/base/base.py
@@ -192,16 +192,8 @@ class BaseDatabaseWrapper:
         Raise an error if the database version isn't supported by this
         version of Django.
         """
-        if (
-            self.features.minimum_database_version is not None
-            and self.get_database_version() < self.features.minimum_database_version
-        ):
-            db_version = ".".join(map(str, self.get_database_version()))
-            min_db_version = ".".join(map(str, self.features.minimum_database_version))
-            raise NotSupportedError(
-                f"{self.display_name} {min_db_version} or later is required "
-                f"(found {db_version})."
-            )
+        db_version = self.get_database_version()
+        self._validate_database_version_supported(db_version)
 
     # ##### Backend-specific methods for creating connections and cursors #####
 
@@ -252,6 +244,7 @@ class BaseDatabaseWrapper:
         self.errors_occurred = False
         # New connections are healthy.
         self.health_check_done = True
+
         # Establish the connection
         conn_params = self.get_connection_params()
         self.connection = self.get_new_connection(conn_params)

--- a/django/db/backends/base/operations.py
+++ b/django/db/backends/base/operations.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.db import NotSupportedError, transaction
 from django.db.models.expressions import Col
 from django.utils import timezone
+from django.utils.codegen import from_codegen, generate_unasynced
 from django.utils.encoding import force_str
 
 
@@ -205,12 +206,21 @@ class BaseDatabaseOperations:
         else:
             return ["DISTINCT"], []
 
+    @from_codegen
     def fetch_returned_insert_columns(self, cursor, returning_params):
         """
         Given a cursor object that has just performed an INSERT...RETURNING
         statement into a table, return the newly created data.
         """
         return cursor.fetchone()
+
+    @generate_unasynced()
+    async def afetch_returned_insert_columns(self, cursor, returning_params):
+        """
+        Given a cursor object that has just performed an INSERT...RETURNING
+        statement into a table, return the newly created data.
+        """
+        return await cursor.afetchone()
 
     def force_group_by(self):
         """

--- a/django/db/backends/postgresql/base.py
+++ b/django/db/backends/postgresql/base.py
@@ -5,7 +5,10 @@ Requires psycopg2 >= 2.8.4 or psycopg >= 3.1.8
 """
 
 import asyncio
+import inspect
+import os
 import threading
+import traceback
 import warnings
 from contextlib import contextmanager
 
@@ -14,11 +17,16 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError as WrappedDatabaseError
 from django.db import connections
 from django.db.backends.base.base import NO_DB_ALIAS, BaseDatabaseWrapper
+from django.db.backends.utils import (
+    AsyncCursorDebugWrapper as AsyncBaseCursorDebugWrapper,
+)
 from django.db.backends.utils import CursorDebugWrapper as BaseCursorDebugWrapper
 from django.utils.asyncio import async_unsafe
 from django.utils.functional import cached_property
 from django.utils.safestring import SafeString
 from django.utils.version import get_version_tuple
+
+LOG_CREATIONS = False
 
 try:
     try:
@@ -86,9 +94,16 @@ def _get_varchar_column(data):
     return "varchar(%(max_length)s)" % data
 
 
+# HACK additions to make OTel instrumentation work properly
+Database.AsyncConnection.pq = Database.pq
+Database.Connection.pq = Database.pq
+
+
 class DatabaseWrapper(BaseDatabaseWrapper):
     vendor = "postgresql"
     display_name = "PostgreSQL"
+    supports_async = is_psycopg3
+
     # This dictionary maps Field objects to their associated PostgreSQL column
     # types, as strings. Column-type strings can contain format strings; they'll
     # be interpolated against the values of Field.__dict__ before being output.
@@ -181,6 +196,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     _named_cursor_idx = 0
     _connection_pools = {}
 
+    def __init__(self, *args, **kwargs):
+        self._creation_stack = "\n".join(traceback.format_stack())
+        super().__init__(*args, **kwargs)
+
     @property
     def pool(self):
         pool_options = self.settings_dict["OPTIONS"].get("pool")
@@ -234,7 +253,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         """
         return divmod(self.pg_version, 10000)
 
-    def get_connection_params(self):
+    def get_connection_params(self, for_async=False):
         settings_dict = self.settings_dict
         # None may be used to connect to the default 'postgres' db
         if settings_dict["NAME"] == "" and not settings_dict["OPTIONS"].get("service"):
@@ -274,14 +293,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             raise ImproperlyConfigured("Database pooling requires psycopg >= 3")
 
         server_side_binding = conn_params.pop("server_side_binding", None)
-        conn_params.setdefault(
-            "cursor_factory",
-            (
-                ServerBindingCursor
-                if is_psycopg3 and server_side_binding is True
-                else Cursor
-            ),
+        cursor_factory = self._get_cursor_factory(
+            server_side_binding, for_async=for_async
         )
+        conn_params.setdefault("cursor_factory", cursor_factory)
         if settings_dict["USER"]:
             conn_params["user"] = settings_dict["USER"]
         if settings_dict["PASSWORD"]:
@@ -301,8 +316,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             )
         return conn_params
 
-    @async_unsafe
-    def get_new_connection(self, conn_params):
+    def _get_isolation_level(self):
         # self.isolation_level must be set:
         # - after connecting to the database in order to obtain the database's
         #   default when no value is explicitly specified in options.
@@ -313,25 +327,30 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         try:
             isolation_level_value = options["isolation_level"]
         except KeyError:
-            self.isolation_level = IsolationLevel.READ_COMMITTED
+            isolation_level = IsolationLevel.READ_COMMITTED
         else:
-            # Set the isolation level to the value from OPTIONS.
             try:
-                self.isolation_level = IsolationLevel(isolation_level_value)
+                isolation_level = IsolationLevel(isolation_level_value)
                 set_isolation_level = True
             except ValueError:
                 raise ImproperlyConfigured(
                     f"Invalid transaction isolation level {isolation_level_value} "
                     f"specified. Use one of the psycopg.IsolationLevel values."
                 )
+        return isolation_level, set_isolation_level
+
+    @async_unsafe
+    def get_new_connection(self, conn_params):
+        isolation_level, set_isolation_level = self._get_isolation_level()
+        self.isolation_level = isolation_level
         if self.pool:
             # If nothing else has opened the pool, open it now.
             self.pool.open()
             connection = self.pool.getconn()
         else:
-            connection = self.Database.connect(**conn_params)
+            connection = Database.Connection.connect(**conn_params)
         if set_isolation_level:
-            connection.isolation_level = self.isolation_level
+            connection.isolation_level = isolation_level
         if not is_psycopg3:
             # Register dummy loads() to avoid a round trip from psycopg2's
             # decode to json.dumps() to json.loads(), when using a custom
@@ -365,6 +384,14 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return True
         return False
 
+    async def _aconfigure_role(self, connection):
+        if new_role := self.settings_dict["OPTIONS"].get("assume_role"):
+            async with connection.acursor() as cursor:
+                sql = self.ops.compose_sql("SET ROLE %s", [new_role])
+                await cursor.aaexecute(sql)
+            return True
+        return False
+
     def _configure_connection(self, connection):
         # This function is called from init_connection_state and from the
         # psycopg pool itself after a connection is opened.
@@ -375,6 +402,19 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # to login is not the same as the role that owns database resources. As
         # can be the case when using temporary or ephemeral credentials.
         commit_role = self._configure_role(connection)
+
+        return commit_role or commit_tz
+
+    async def _aconfigure_connection(self, connection):
+        # This function is called from init_connection_state and from the
+        # psycopg pool itself after a connection is opened.
+
+        # Commit after setting the time zone.
+        commit_tz = await self._aconfigure_timezone(connection)
+        # Set the role on the connection. This is useful if the credential used
+        # to login is not the same as the role that owns database resources. As
+        # can be the case when using temporary or ephemeral credentials.
+        commit_role = await self._aconfigure_role(connection)
 
         return commit_role or commit_tz
 

--- a/django/db/backends/utils.py
+++ b/django/db/backends/utils.py
@@ -11,7 +11,54 @@ from django.apps import apps
 from django.db import NotSupportedError
 from django.utils.dateparse import parse_time
 
+from asgiref.local import Local
+
 logger = logging.getLogger("django.db.backends")
+
+# XXX experimentation
+sync_cursor_ops_local = Local()
+sync_cursor_ops_local.value = False
+
+
+# XXX experimentation
+class sync_cursor_ops_blocked:
+    @classmethod
+    def get(cls):
+        # This is extremely wrong! Maybe. To think about
+        try:
+            return sync_cursor_ops_local.value
+        except AttributeError:
+            # if it's not set... it's not True
+            sync_cursor_ops_local.value = False
+            return False
+
+    @classmethod
+    def set(cls, v):
+        sync_cursor_ops_local.value = v
+
+
+# XXX experimentation
+@contextmanager
+def block_sync_ops():
+    old_val = sync_cursor_ops_blocked.get()
+    sync_cursor_ops_blocked.set(True)
+    try:
+        print("Started blocking sync ops.")
+        yield
+    finally:
+        sync_cursor_ops_blocked.set(old_val)
+        print("Stopped blocking sync ops.")
+
+
+# XXX experimentation
+@contextmanager
+def unblock_sync_ops():
+    old_val = sync_cursor_ops_blocked.get()
+    sync_cursor_ops_blocked.set(False)
+    try:
+        yield
+    finally:
+        sync_cursor_ops_blocked.set(old_val)
 
 
 class CursorWrapper:
@@ -21,6 +68,10 @@ class CursorWrapper:
 
     WRAP_ERROR_ATTRS = frozenset(["fetchone", "fetchmany", "fetchall", "nextset"])
 
+    # XXX experimentation
+    SYNC_BLOCK = {"close"}
+    # XXX experimentation
+    SAFE_LIST = set()
     APPS_NOT_READY_WARNING_MSG = (
         "Accessing the database during app initialization is discouraged. To fix this "
         "warning, avoid executing queries in AppConfig.ready() or when your app "
@@ -28,6 +79,18 @@ class CursorWrapper:
     )
 
     def __getattr__(self, attr):
+        # XXX experimentation
+        # (the point here is being able to focus on a chunk of code in a specific
+        #  way to identify if something is unintentionally falling back to sync ops)
+        if sync_cursor_ops_blocked.get():
+            if attr in CursorWrapper.WRAP_ERROR_ATTRS:
+                raise ValueError("Sync operations blocked!")
+            elif attr in CursorWrapper.SYNC_BLOCK:
+                raise ValueError("Sync operations blocked!")
+            elif attr in CursorWrapper.SAFE_LIST:
+                pass
+            else:
+                print(f"CursorWrapper.{attr} accessed")
         cursor_attr = getattr(self.cursor, attr)
         if attr in CursorWrapper.WRAP_ERROR_ATTRS:
             return self.db.wrap_database_errors(cursor_attr)
@@ -176,18 +239,21 @@ def debug_transaction(connection, sql):
                 {
                     "sql": "%s" % sql,
                     "time": "%.3f" % duration,
+                    "async": connection.supports_async,
                 }
             )
             logger.debug(
-                "(%.3f) %s; args=%s; alias=%s",
+                "(%.3f) %s; args=%s; alias=%s; async=%s",
                 duration,
                 sql,
                 None,
                 connection.alias,
+                connection.supports_async,
                 extra={
                     "duration": duration,
                     "sql": sql,
                     "alias": connection.alias,
+                    "async": connection.supports_async,
                 },
             )
 

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from functools import partialmethod
 from itertools import chain
 
-from asgiref.sync import sync_to_async
+from asgiref.sync import async_to_sync, sync_to_async
 
 import django
 from django.apps import apps
@@ -801,7 +801,6 @@ class Model(AltersData, metaclass=ModelBase):
         that the "save" must be an SQL insert or update (or equivalent for
         non-SQL backends), respectively. Normally, they should not be set.
         """
-
         self._prepare_related_fields_for_save(operation_name="save")
 
         using = using or router.db_for_write(self.__class__, instance=self)

--- a/django/db/models/deletion.py
+++ b/django/db/models/deletion.py
@@ -113,6 +113,12 @@ class Collector:
         # parent.
         self.dependencies = defaultdict(set)  # {model: {models}}
 
+    def bool(self, elts):
+        if hasattr(elts, "_afetch_then_len"):
+            return bool(elts._fetch_then_len())
+        else:
+            return bool(elts)
+
     def add(self, objs, source=None, nullable=False, reverse_dependency=False):
         """
         Add 'objs' to the collection of objects to be deleted.  If the call is
@@ -121,7 +127,8 @@ class Collector:
 
         Return a list of all objects that were not already collected.
         """
-        if not objs:
+        # XXX incorrect hack
+        if not self.bool(objs):
             return []
         new_objs = []
         model = objs[0].__class__

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -18,6 +18,7 @@ from django.db import (
     NotSupportedError,
     connections,
     router,
+    # should_use_sync_fallback,
     transaction,
 )
 from django.db.models import AutoField, DateField, DateTimeField, Field, sql
@@ -26,7 +27,7 @@ from django.db.models.deletion import Collector
 from django.db.models.expressions import Case, F, Value, When
 from django.db.models.functions import Cast, Trunc
 from django.db.models.query_utils import FilteredRelation, Q
-from django.db.models.sql.constants import GET_ITERATOR_CHUNK_SIZE, ROW_COUNT
+from django.db.models.sql.constants import ROW_COUNT, GET_ITERATOR_CHUNK_SIZE
 from django.db.models.utils import (
     AltersData,
     create_namedtuple_class,
@@ -50,11 +51,11 @@ class BaseIterable:
         self.chunked_fetch = chunked_fetch
         self.chunk_size = chunk_size
 
-    async def _async_generator(self):
+    async def _sync_to_async_generator(self):
         # Generators don't actually start running until the first time you call
         # next() on them, so make the generator object in the async thread and
         # then repeatedly dispatch to it in a sync thread.
-        sync_generator = self.__iter__()
+        sync_generator = await sync_to_async(self.__iter__)()
 
         def next_slice(gen):
             return list(islice(gen, self.chunk_size))
@@ -66,6 +67,8 @@ class BaseIterable:
             if len(chunk) < self.chunk_size:
                 break
 
+    _async_generator = _sync_to_async_generator
+
     # __aiter__() is a *synchronous* method that has to then return an
     # *asynchronous* iterator/generator. Thus, nest an async generator inside
     # it.
@@ -75,13 +78,29 @@ class BaseIterable:
     # be added to each Iterable subclass, but that needs some work in the
     # Compiler first.
     def __aiter__(self):
-        return self._async_generator()
+        # not clear to me if we need this fallback, to investigate
+        if should_use_sync_fallback(ASYNC_TRUTH_MARKER):
+            return self._sync_to_async_generator()
+        else:
+            return self._agenerator()
+
+    def __iter__(self):
+        return self._generator()
+
+    def _generator(self):
+        raise NotImplementedError()
+
+    def _agenerator(self):
+        raise NotImeplementedError()
 
 
 class ModelIterable(BaseIterable):
     """Iterable that yields a model instance for each row."""
 
     def __iter__(self):
+        return self._generator()
+
+    def _generator(self):
         queryset = self.queryset
         db = queryset.db
         compiler = queryset.query.get_compiler(using=db)
@@ -361,9 +380,12 @@ class QuerySet(AltersData):
             data[-1] = "...(remaining elements truncated)..."
         return "<%s %r>" % (self.__class__.__name__, data)
 
-    def __len__(self):
+    def _fetch_then_len(self):
         self._fetch_all()
         return len(self._result_cache)
+
+    def __len__(self):
+        return self._fetch_then_len()
 
     def __iter__(self):
         """
@@ -387,7 +409,7 @@ class QuerySet(AltersData):
         # Remember, __aiter__ itself is synchronous, it's the thing it returns
         # that is async!
         async def generator():
-            await sync_to_async(self._fetch_all)()
+            await self._afetch_all()
             for item in self._result_cache:
                 yield item
 
@@ -625,7 +647,7 @@ class QuerySet(AltersData):
         ):
             limit = MAX_GET_RESULTS
             clone.query.set_limits(high=limit)
-        num = len(clone)
+        num = clone._fetch_then_len()
         if num == 1:
             return clone._result_cache[0]
         if not num:
@@ -1250,7 +1272,7 @@ class QuerySet(AltersData):
 
         # Clear any annotations so that they won't be present in subqueries.
         query.annotations = {}
-        with transaction.mark_for_rollback_on_error(using=self.db):
+        with transaction.amark_for_rollback_on_error(using=self.db):
             rows = query.get_compiler(self.db).execute_sql(ROW_COUNT)
         self._result_cache = None
         return rows
@@ -1926,7 +1948,7 @@ class QuerySet(AltersData):
 
     def _fetch_all(self):
         if self._result_cache is None:
-            self._result_cache = list(self._iterable_class(self))
+            self._result_cache = [elt for elt in self._iterable_class(self)]
         if self._prefetch_related_lookups and not self._prefetch_done:
             self._prefetch_related_objects()
 
@@ -2115,6 +2137,10 @@ class RawQuerySet:
             self._result_cache = list(self.iterator())
         if self._prefetch_related_lookups and not self._prefetch_done:
             self._prefetch_related_objects()
+
+    def _fetch_then_len(self):
+        self._fetch_all()
+        return len(self._result_cache)
 
     def __len__(self):
         self._fetch_all()

--- a/django/db/models/sql/compiler.py
+++ b/django/db/models/sql/compiler.py
@@ -3,6 +3,7 @@ import json
 import re
 from functools import partial
 from itertools import chain
+from typing import AsyncGenerator
 
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import DatabaseError, NotSupportedError
@@ -13,8 +14,8 @@ from django.db.models.functions import Cast, Random
 from django.db.models.lookups import Lookup
 from django.db.models.query_utils import select_related_descend
 from django.db.models.sql.constants import (
-    CURSOR,
     GET_ITERATOR_CHUNK_SIZE,
+    CURSOR,
     MULTI,
     NO_RESULTS,
     ORDER_DIR,
@@ -27,6 +28,7 @@ from django.db.transaction import TransactionManagementError
 from django.utils.functional import cached_property
 from django.utils.hashable import make_hashable
 from django.utils.regex_helper import _lazy_re_compile
+from django.utils.codegen import from_codegen, generate_unasynced, ASYNC_TRUTH_MARKER
 
 
 class PositionRef(Ref):
@@ -1572,6 +1574,12 @@ class SQLCompiler:
             results = self.execute_sql(
                 MULTI, chunked_fetch=chunked_fetch, chunk_size=chunk_size
             )
+        else:
+            # XXX wrong
+            # this is forcing evaluation of athing way to early
+            # instead of being an actual iterable
+            if isinstance(results, AsyncGenerator):
+                results = [r for r in results]
         fields = [s[0] for s in self.select[0 : self.col_count]]
         converters = self.get_converters(fields)
         rows = chain.from_iterable(results)
@@ -1619,6 +1627,7 @@ class SQLCompiler:
             cursor = self.connection.chunked_cursor()
         else:
             cursor = self.connection.cursor()
+
         try:
             cursor.execute(sql, params)
         except Exception:
@@ -1631,10 +1640,9 @@ class SQLCompiler:
                 return cursor.rowcount
             finally:
                 cursor.close()
-        if result_type == CURSOR:
-            # Give the caller the cursor to process and close.
+        elif result_type == CURSOR:
             return cursor
-        if result_type == SINGLE:
+        elif result_type == SINGLE:
             try:
                 val = cursor.fetchone()
                 if val:
@@ -1643,23 +1651,29 @@ class SQLCompiler:
             finally:
                 # done with the cursor
                 cursor.close()
-        if result_type == NO_RESULTS:
+        elif result_type == NO_RESULTS:
             cursor.close()
             return
-
-        result = cursor_iter(
-            cursor,
-            self.connection.features.empty_fetchmany_value,
-            self.col_count if self.has_extra_select else None,
-            chunk_size,
-        )
-        if not chunked_fetch or not self.connection.features.can_use_chunked_reads:
-            # If we are using non-chunked reads, we return the same data
-            # structure as normally, but ensure it is all read into memory
-            # before going any further. Use chunked_fetch if requested,
-            # unless the database doesn't support it.
-            return list(result)
-        return result
+        elif result_type == ROW_COUNT:
+            try:
+                return cursor.rowcount
+            finally:
+                cursor.close()
+        else:
+            assert result_type == MULTI
+            result = cursor_iter(
+                cursor,
+                self.connection.features.empty_fetchmany_value,
+                self.col_count if self.has_extra_select else None,
+                chunk_size,
+            )
+            if not chunked_fetch or not self.connection.features.can_use_chunked_reads:
+                # If we are using non-chunked reads, we return the same data
+                # structure as normally, but ensure it is all read into memory
+                # before going any further. Use chunked_fetch if requested,
+                # unless the database doesn't support it.
+                return [elt for elt in result]
+            return result
 
     def as_subquery_condition(self, alias, columns, compiler):
         qn = compiler.quote_name_unless_alias
@@ -1923,6 +1937,7 @@ class SQLInsertCompiler(SQLCompiler):
                         ),
                     )
                 ]
+
             else:
                 # Backend doesn't support returning fields and no auto-field
                 # that can be retrieved from `last_insert_id` was specified.
@@ -1994,6 +2009,7 @@ class SQLDeleteCompiler(SQLCompiler):
 
 
 class SQLUpdateCompiler(SQLCompiler):
+
     def as_sql(self):
         """
         Create the SQL for this query. Return the SQL string and list of
@@ -2079,7 +2095,7 @@ class SQLUpdateCompiler(SQLCompiler):
                 is_empty = False
         return row_count
 
-    def pre_sql_setup(self):
+    def pre_sql_setup(self, with_col_aliases=False):
         """
         If the update depends on results from other tables, munge the "where"
         conditions to match the format required for (portable) SQL updates.
@@ -2116,7 +2132,7 @@ class SQLUpdateCompiler(SQLCompiler):
                 related_ids_index.append((related, len(fields)))
                 fields.append(related._meta.pk.name)
         query.add_fields(fields)
-        super().pre_sql_setup()
+        super().pre_sql_setup(with_col_aliases=with_col_aliases)
 
         is_composite_pk = meta.is_composite_pk
         must_pre_select = (
@@ -2146,6 +2162,7 @@ class SQLUpdateCompiler(SQLCompiler):
 
 
 class SQLAggregateCompiler(SQLCompiler):
+
     def as_sql(self):
         """
         Create the SQL for this query. Return the SQL string and list of
@@ -2176,7 +2193,10 @@ def cursor_iter(cursor, sentinel, col_count, itersize):
     done.
     """
     try:
-        for rows in iter((lambda: cursor.fetchmany(itersize)), sentinel):
+        while True:
+            rows = cursor.fetchmany(itersize)
+            if rows == sentinel:
+                break
             yield rows if col_count is None else [r[:col_count] for r in rows]
     finally:
         cursor.close()

--- a/django/db/models/sql/constants.py
+++ b/django/db/models/sql/constants.py
@@ -9,8 +9,12 @@ GET_ITERATOR_CHUNK_SIZE = 100
 # Namedtuples for sql.* internal use.
 
 # How many results to expect from a cursor.execute call
+# multiple rows are expected
 MULTI = "multi"
+# a single row is expected
 SINGLE = "single"
+# instead of returning the rows, return the row count
+CURSOR = "cursor"
 NO_RESULTS = "no results"
 # Rather than returning results, returns:
 CURSOR = "cursor"

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -17,7 +17,11 @@ from itertools import chain, count, product
 from string import ascii_uppercase
 
 from django.core.exceptions import FieldDoesNotExist, FieldError
-from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections
+from django.db import (
+    DEFAULT_DB_ALIAS,
+    NotSupportedError,
+    connections,
+)
 from django.db.models.aggregates import Count
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import (
@@ -42,6 +46,7 @@ from django.db.models.query_utils import (
 from django.db.models.sql.constants import INNER, LOUTER, ORDER_DIR, SINGLE
 from django.db.models.sql.datastructures import BaseTable, Empty, Join, MultiJoin
 from django.db.models.sql.where import AND, OR, ExtraWhere, NothingNode, WhereNode
+from django.utils.codegen import ASYNC_TRUTH_MARKER, from_codegen, generate_unasynced
 from django.utils.functional import cached_property
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.tree import Node
@@ -355,11 +360,13 @@ class Query(BaseExpression):
         memo[id(self)] = result
         return result
 
-    def get_compiler(self, using=None, connection=None, elide_empty=True):
+    def get_compiler(
+        self, using=None, connection=None, elide_empty=True, raise_on_miss=False
+    ):
         if using is None and connection is None:
             raise ValueError("Need either using or connection")
         if using:
-            connection = connections[using]
+            connection = connections.get_item(using, raise_on_miss=raise_on_miss)
         return connection.ops.compiler(self.compiler)(
             self, connection, using, elide_empty
         )
@@ -443,6 +450,7 @@ class Query(BaseExpression):
             alias = None
         return target.get_col(alias, field)
 
+    @from_codegen
     def get_aggregation(self, using, aggregate_exprs):
         """
         Return the dictionary with the values of the existing aggregations.
@@ -636,12 +644,218 @@ class Query(BaseExpression):
 
         return dict(zip(outer_query.annotation_select, result))
 
+    @generate_unasynced()
+    async def aget_aggregation(self, using, aggregate_exprs):
+        """
+        Return the dictionary with the values of the existing aggregations.
+        """
+        if not aggregate_exprs:
+            return {}
+        # Store annotation mask prior to temporarily adding aggregations for
+        # resolving purpose to facilitate their subsequent removal.
+        refs_subquery = False
+        refs_window = False
+        replacements = {}
+        annotation_select_mask = self.annotation_select_mask
+        for alias, aggregate_expr in aggregate_exprs.items():
+            self.check_alias(alias)
+            aggregate = aggregate_expr.resolve_expression(
+                self, allow_joins=True, reuse=None, summarize=True
+            )
+            if not aggregate.contains_aggregate:
+                raise TypeError("%s is not an aggregate expression" % alias)
+            # Temporarily add aggregate to annotations to allow remaining
+            # members of `aggregates` to resolve against each others.
+            self.append_annotation_mask([alias])
+            aggregate_refs = aggregate.get_refs()
+            refs_subquery |= any(
+                getattr(self.annotations[ref], "contains_subquery", False)
+                for ref in aggregate_refs
+            )
+            refs_window |= any(
+                getattr(self.annotations[ref], "contains_over_clause", True)
+                for ref in aggregate_refs
+            )
+            aggregate = aggregate.replace_expressions(replacements)
+            self.annotations[alias] = aggregate
+            replacements[Ref(alias, aggregate)] = aggregate
+        # Stash resolved aggregates now that they have been allowed to resolve
+        # against each other.
+        aggregates = {alias: self.annotations.pop(alias) for alias in aggregate_exprs}
+        self.set_annotation_mask(annotation_select_mask)
+        # Existing usage of aggregation can be determined by the presence of
+        # selected aggregates but also by filters against aliased aggregates.
+        _, having, qualify = self.where.split_having_qualify()
+        has_existing_aggregation = (
+            any(
+                getattr(annotation, "contains_aggregate", True)
+                for annotation in self.annotations.values()
+            )
+            or having
+        )
+        set_returning_annotations = {
+            alias
+            for alias, annotation in self.annotation_select.items()
+            if getattr(annotation, "set_returning", False)
+        }
+        # Decide if we need to use a subquery.
+        #
+        # Existing aggregations would cause incorrect results as
+        # get_aggregation() must produce just one result and thus must not use
+        # GROUP BY.
+        #
+        # If the query has limit or distinct, or uses set operations, then
+        # those operations must be done in a subquery so that the query
+        # aggregates on the limit and/or distinct results instead of applying
+        # the distinct and limit after the aggregation.
+        if (
+            isinstance(self.group_by, tuple)
+            or self.is_sliced
+            or has_existing_aggregation
+            or refs_subquery
+            or refs_window
+            or qualify
+            or self.distinct
+            or self.combinator
+            or set_returning_annotations
+        ):
+            from django.db.models.sql.subqueries import AggregateQuery
+
+            inner_query = self.clone()
+            inner_query.subquery = True
+            outer_query = AggregateQuery(self.model, inner_query)
+            inner_query.select_for_update = False
+            inner_query.select_related = False
+            inner_query.set_annotation_mask(self.annotation_select)
+            # Queries with distinct_fields need ordering and when a limit is
+            # applied we must take the slice from the ordered query. Otherwise
+            # no need for ordering.
+            inner_query.clear_ordering(force=False)
+            if not inner_query.distinct:
+                # If the inner query uses default select and it has some
+                # aggregate annotations, then we must make sure the inner
+                # query is grouped by the main model's primary key. However,
+                # clearing the select clause can alter results if distinct is
+                # used.
+                if inner_query.default_cols and has_existing_aggregation:
+                    inner_query.group_by = (
+                        self.model._meta.pk.get_col(inner_query.get_initial_alias()),
+                    )
+                inner_query.default_cols = False
+                if not qualify and not self.combinator:
+                    # Mask existing annotations that are not referenced by
+                    # aggregates to be pushed to the outer query unless
+                    # filtering against window functions or if the query is
+                    # combined as both would require complex realiasing logic.
+                    annotation_mask = set()
+                    if isinstance(self.group_by, tuple):
+                        for expr in self.group_by:
+                            annotation_mask |= expr.get_refs()
+                    for aggregate in aggregates.values():
+                        annotation_mask |= aggregate.get_refs()
+                    # Avoid eliding expressions that might have an incidence on
+                    # the implicit grouping logic.
+                    for annotation_alias, annotation in self.annotation_select.items():
+                        if annotation.get_group_by_cols():
+                            annotation_mask.add(annotation_alias)
+                    inner_query.set_annotation_mask(annotation_mask)
+                    # Annotations that possibly return multiple rows cannot
+                    # be masked as they might have an incidence on the query.
+                    annotation_mask |= set_returning_annotations
+
+            # Add aggregates to the outer AggregateQuery. This requires making
+            # sure all columns referenced by the aggregates are selected in the
+            # inner query. It is achieved by retrieving all column references
+            # by the aggregates, explicitly selecting them in the inner query,
+            # and making sure the aggregates are repointed to them.
+            col_refs = {}
+            for alias, aggregate in aggregates.items():
+                replacements = {}
+                for col in self._gen_cols([aggregate], resolve_refs=False):
+                    if not (col_ref := col_refs.get(col)):
+                        index = len(col_refs) + 1
+                        col_alias = f"__col{index}"
+                        col_ref = Ref(col_alias, col)
+                        col_refs[col] = col_ref
+                        inner_query.add_annotation(col, col_alias)
+                    replacements[col] = col_ref
+                outer_query.annotations[alias] = aggregate.replace_expressions(
+                    replacements
+                )
+            if (
+                inner_query.select == ()
+                and not inner_query.default_cols
+                and not inner_query.annotation_select_mask
+            ):
+                # In case of Model.objects[0:3].count(), there would be no
+                # field selected in the inner query, yet we must use a subquery.
+                # So, make sure at least one field is selected.
+                inner_query.select = (
+                    self.model._meta.pk.get_col(inner_query.get_initial_alias()),
+                )
+        else:
+            outer_query = self
+            self.select = ()
+            self.selected = None
+            self.default_cols = False
+            self.extra = {}
+            if self.annotations:
+                # Inline reference to existing annotations and mask them as
+                # they are unnecessary given only the summarized aggregations
+                # are requested.
+                replacements = {
+                    Ref(alias, annotation): annotation
+                    for alias, annotation in self.annotations.items()
+                }
+                self.annotations = {
+                    alias: aggregate.replace_expressions(replacements)
+                    for alias, aggregate in aggregates.items()
+                }
+            else:
+                self.annotations = aggregates
+            self.set_annotation_mask(aggregates)
+
+        empty_set_result = [
+            expression.empty_result_set_value
+            for expression in outer_query.annotation_select.values()
+        ]
+        elide_empty = not any(result is NotImplemented for result in empty_set_result)
+        outer_query.clear_ordering(force=True)
+        outer_query.clear_limits()
+        outer_query.select_for_update = False
+        outer_query.select_related = False
+        if ASYNC_TRUTH_MARKER:
+            compiler = outer_query.aget_compiler(using, elide_empty=elide_empty)
+        else:
+            compiler = outer_query.get_compiler(using, elide_empty=elide_empty)
+        result = await compiler.aexecute_sql(SINGLE)
+        if result is None:
+            result = empty_set_result
+        else:
+            cols = outer_query.annotation_select.values()
+            converters = compiler.get_converters(cols)
+            rows = compiler.apply_converters((result,), converters)
+            if compiler.has_composite_fields(cols):
+                rows = compiler.composite_fields_to_tuples(rows, cols)
+            result = next(rows)
+
+        return dict(zip(outer_query.annotation_select, result))
+
+    @from_codegen
     def get_count(self, using):
         """
         Perform a COUNT() query using the current filter constraints.
         """
         obj = self.clone()
         return obj.get_aggregation(using, {"__count": Count("*")})["__count"]
+
+    @generate_unasynced()
+    async def aget_count(self, using):
+        """
+        Perform a COUNT() query using the current filter constraints.
+        """
+        obj = self.clone()
+        return (await obj.aget_aggregation(using, {"__count": Count("*")}))["__count"]
 
     def has_filters(self):
         return self.where
@@ -668,11 +882,22 @@ class Query(BaseExpression):
         q.add_annotation(Value(1), "a")
         return q
 
+    @from_codegen
     def has_results(self, using):
         q = self.exists()
         compiler = q.get_compiler(using=using)
         return compiler.has_results()
 
+    @generate_unasynced()
+    async def ahas_results(self, using):
+        q = self.exists()
+        if ASYNC_TRUTH_MARKER:
+            compiler = q.aget_compiler(using=using)
+        else:
+            compiler = q.get_compiler(using=using)
+        return await compiler.ahas_results()
+
+    @from_codegen
     def explain(self, using, format=None, **options):
         q = self.clone()
         for option_name in options:
@@ -684,6 +909,22 @@ class Query(BaseExpression):
         q.explain_info = ExplainInfo(format, options)
         compiler = q.get_compiler(using=using)
         return "\n".join(compiler.explain_query())
+
+    @generate_unasynced()
+    async def aexplain(self, using, format=None, **options):
+        q = self.clone()
+        for option_name in options:
+            if (
+                not EXPLAIN_OPTIONS_PATTERN.fullmatch(option_name)
+                or "--" in option_name
+            ):
+                raise ValueError(f"Invalid option name: {option_name!r}.")
+        q.explain_info = ExplainInfo(format, options)
+        if ASYNC_TRUTH_MARKER:
+            compiler = q.aget_compiler(using=using)
+        else:
+            compiler = q.get_compiler(using=using)
+        return "\n".join(await compiler.aexplain_query())
 
     def combine(self, rhs, connector):
         """

--- a/django/db/models/sql/subqueries.py
+++ b/django/db/models/sql/subqueries.py
@@ -9,6 +9,7 @@ from django.db.models.sql.constants import (
     ROW_COUNT,
 )
 from django.db.models.sql.query import Query
+from django.utils.codegen import from_codegen, generate_unasynced
 
 __all__ = ["DeleteQuery", "UpdateQuery", "InsertQuery", "AggregateQuery"]
 
@@ -18,11 +19,21 @@ class DeleteQuery(Query):
 
     compiler = "SQLDeleteCompiler"
 
+    @from_codegen
     def do_query(self, table, where, using):
         self.alias_map = {table: self.alias_map[table]}
         self.where = where
+
         return self.get_compiler(using).execute_sql(ROW_COUNT)
 
+    @generate_unasynced()
+    async def ado_query(self, table, where, using):
+        self.alias_map = {table: self.alias_map[table]}
+        self.where = where
+
+        return await self.aget_compiler(using).aexecute_sql(ROW_COUNT)
+
+    @from_codegen
     def delete_batch(self, pk_list, using):
         """
         Set up and execute delete queries for all the objects in pk_list.
@@ -40,6 +51,28 @@ class DeleteQuery(Query):
                 pk_list[offset : offset + GET_ITERATOR_CHUNK_SIZE],
             )
             num_deleted += self.do_query(
+                self.get_meta().db_table, self.where, using=using
+            )
+        return num_deleted
+
+    @generate_unasynced()
+    async def adelete_batch(self, pk_list, using):
+        """
+        Set up and execute delete queries for all the objects in pk_list.
+
+        More than one physical query may be executed if there are a
+        lot of values in pk_list.
+        """
+        # number of objects deleted
+        num_deleted = 0
+        field = self.get_meta().pk
+        for offset in range(0, len(pk_list), GET_ITERATOR_CHUNK_SIZE):
+            self.clear_where()
+            self.add_filter(
+                f"{field.attname}__in",
+                pk_list[offset : offset + GET_ITERATOR_CHUNK_SIZE],
+            )
+            num_deleted += await self.ado_query(
                 self.get_meta().db_table, self.where, using=using
             )
         return num_deleted

--- a/django/db/transaction.py
+++ b/django/db/transaction.py
@@ -1,4 +1,9 @@
-from contextlib import ContextDecorator, contextmanager
+import asyncio
+from contextlib import ContextDecorator, asynccontextmanager, contextmanager
+import contextvars
+import weakref
+
+from asgiref.sync import sync_to_async
 
 from django.db import (
     DEFAULT_DB_ALIAS,
@@ -7,6 +12,7 @@ from django.db import (
     ProgrammingError,
     connections,
 )
+from django.utils.codegen import ASYNC_TRUTH_MARKER, generate_unasynced
 
 
 class TransactionManagementError(ProgrammingError):
@@ -23,6 +29,14 @@ def get_connection(using=None):
     if using is None:
         using = DEFAULT_DB_ALIAS
     return connections[using]
+
+
+async def aget_connection(using=None):
+    from django.db import async_connections
+
+    if using is None:
+        using = DEFAULT_DB_ALIAS
+    return async_connections.get_connection(using)
 
 
 def get_autocommit(using=None):
@@ -97,7 +111,35 @@ def set_rollback(rollback, using=None):
     return get_connection(using).set_rollback(rollback)
 
 
-@contextmanager
+class MarkForRollbackOnError:
+    def __init__(self, using):
+        self.using = using
+
+    def __enter__(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is not None:
+            connection = await aget_connection(self.using)
+            if connection.in_atomic_block:
+                connection.needs_rollback = True
+                connection.rollback_exc = exc_val
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is not None:
+            connection = get_connection(self.using)
+            if connection.in_atomic_block:
+                connection.needs_rollback = True
+                connection.rollback_exc = exc_val
+
+
+def amark_for_rollback_on_error(using=None):
+    return MarkForRollbackOnError(using=using)
+
+
 def mark_for_rollback_on_error(using=None):
     """
     Internal low-level utility to mark a transaction as "needs rollback" when
@@ -116,14 +158,7 @@ def mark_for_rollback_on_error(using=None):
 
     but it uses low-level utilities to avoid performance overhead.
     """
-    try:
-        yield
-    except Exception as exc:
-        connection = get_connection(using)
-        if connection.in_atomic_block:
-            connection.needs_rollback = True
-            connection.rollback_exc = exc
-        raise
+    return MarkForRollbackOnError(using=using)
 
 
 def on_commit(func, using=None, robust=False):
@@ -179,7 +214,25 @@ class Atomic(ContextDecorator):
         self.durable = durable
         self._from_testcase = False
 
+    # tracking how many atomic transactions I have done
+    _atomic_depth_ctx: dict[str, contextvars.ContextVar] = {}
+
+    def atomic_depth_var(self, using):
+        if using is None:
+            using = DEFAULT_DB_ALIAS
+        # XXX race?
+        if using not in self._atomic_depth_ctx:
+            # XXX awkward context var
+            self._atomic_depth_ctx[using] = contextvars.ContextVar(using, default=0)
+        return self._atomic_depth_ctx[using]
+
+    def current_atomic_depth(self, using):
+        return self.atomic_depth_var(using).get()
+
     def __enter__(self):
+
+        current_depth = self.atomic_depth_var(self.using)
+        current_depth.set(current_depth.get() + 1)
         connection = get_connection(self.using)
 
         if (
@@ -221,7 +274,70 @@ class Atomic(ContextDecorator):
         if connection.in_atomic_block:
             connection.atomic_blocks.append(self)
 
+    atxn_locks = weakref.WeakKeyDictionary()
+
+    def get_atxn_lock(self, connection) -> asyncio.Lock:
+        lock = self.atxn_locks.get(connection, None)
+        if lock is None:
+            lock = self.atxn_locks[connection] = asyncio.Lock()
+        return lock
+
+    # need to figure out how to generate __enter__ from __aenter__
+    # @generate_unasynced()
+    async def __aenter__(self):
+        from django.db import should_use_sync_fallback
+
+        if should_use_sync_fallback(ASYNC_TRUTH_MARKER):
+            return await sync_to_async(self.__enter__)()
+        current_depth = self.atomic_depth_var(self.using)
+        current_depth.set(current_depth.get() + 1)
+        connection = await aget_connection(self.using)
+
+        if (
+            self.durable
+            and connection.atomic_blocks
+            and not connection.atomic_blocks[-1]._from_testcase
+        ):
+            raise RuntimeError(
+                "A durable atomic block cannot be nested within another "
+                "atomic block."
+            )
+
+        # XXX race
+        async with self.get_atxn_lock(connection):
+            if not connection.in_atomic_block:
+                # Reset state when entering an outermost atomic block.
+                connection.commit_on_exit = True
+                connection.needs_rollback = False
+                if not (await connection.aget_autocommit()):
+                    # Pretend we're already in an atomic block to bypass the code
+                    # that disables autocommit to enter a transaction, and make a
+                    # note to deal with this case in __exit__.
+                    connection.in_atomic_block = True
+                    connection.commit_on_exit = False
+
+            if connection.in_atomic_block:
+                # We're already in a transaction; create a savepoint, unless we
+                # were told not to or we're already waiting for a rollback. The
+                # second condition avoids creating useless savepoints and prevents
+                # overwriting needs_rollback until the rollback is performed.
+                if self.savepoint and not connection.needs_rollback:
+                    sid = await connection.asavepoint()
+                    connection.savepoint_ids.append(sid)
+                else:
+                    connection.savepoint_ids.append(None)
+            else:
+                await connection.aset_autocommit(
+                    False, force_begin_transaction_with_broken_autocommit=True
+                )
+                connection.in_atomic_block = True
+
+            if connection.in_atomic_block:
+                connection.atomic_blocks.append(self)
+
     def __exit__(self, exc_type, exc_value, traceback):
+        current_depth = self.atomic_depth_var(self.using)
+        current_depth.set(current_depth.get() - 1)
         connection = get_connection(self.using)
 
         if connection.in_atomic_block:
@@ -311,6 +427,103 @@ class Atomic(ContextDecorator):
                     connection.connection = None
                 else:
                     connection.in_atomic_block = False
+
+    # XXX try to get this working through generation as well
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        if should_use_sync_fallback(ASYNC_TRUTH_MARKER):
+            return await sync_to_async(self.__exit__)(exc_type, exc_value, traceback)
+        current_depth = self.atomic_depth_var(self.using)
+        current_depth.set(current_depth.get() - 1)
+        connection = await aget_connection(self.using)
+
+        async with self.get_atxn_lock(connection):
+            if connection.in_atomic_block:
+                connection.atomic_blocks.pop()
+
+            if connection.savepoint_ids:
+                sid = connection.savepoint_ids.pop()
+            else:
+                # Prematurely unset this flag to allow using commit or rollback.
+                connection.in_atomic_block = False
+
+            try:
+                if connection.closed_in_transaction:
+                    # The database will perform a rollback by itself.
+                    # Wait until we exit the outermost block.
+                    pass
+
+                elif exc_type is None and not connection.needs_rollback:
+                    if connection.in_atomic_block:
+                        # Release savepoint if there is one
+                        if sid is not None:
+                            try:
+                                await connection.asavepoint_commit(sid)
+                            except DatabaseError:
+                                try:
+                                    await connection.asavepoint_rollback(sid)
+                                    # The savepoint won't be reused. Release it to
+                                    # minimize overhead for the database server.
+                                    await connection.asavepoint_commit(sid)
+                                except Error:
+                                    # If rolling back to a savepoint fails, mark for
+                                    # rollback at a higher level and avoid shadowing
+                                    # the original exception.
+                                    connection.needs_rollback = True
+                                raise
+                    else:
+                        # Commit transaction
+                        try:
+                            await connection.acommit()
+                        except DatabaseError:
+                            try:
+                                await connection.arollback()
+                            except Error:
+                                # An error during rollback means that something
+                                # went wrong with the connection. Drop it.
+                                await connection.aclose()
+                            raise
+                else:
+                    # This flag will be set to True again if there isn't a savepoint
+                    # allowing to perform the rollback at this level.
+                    connection.needs_rollback = False
+                    if connection.in_atomic_block:
+                        # Roll back to savepoint if there is one, mark for rollback
+                        # otherwise.
+                        if sid is None:
+                            connection.needs_rollback = True
+                        else:
+                            try:
+                                await connection.asavepoint_rollback(sid)
+                                # The savepoint won't be reused. Release it to
+                                # minimize overhead for the database server.
+                                await connection.asavepoint_commit(sid)
+                            except Error:
+                                # If rolling back to a savepoint fails, mark for
+                                # rollback at a higher level and avoid shadowing
+                                # the original exception.
+                                connection.needs_rollback = True
+                    else:
+                        # Roll back transaction
+                        try:
+                            await connection.arollback()
+                        except Error:
+                            # An error during rollback means that something
+                            # went wrong with the connection. Drop it.
+                            await connection.aclose()
+
+            finally:
+                # Outermost block exit when autocommit was enabled.
+                if not connection.in_atomic_block:
+                    if connection.closed_in_transaction:
+                        connection.connection = None
+                    else:
+                        connection.set_autocommit(True)
+                # Outermost block exit when autocommit was disabled.
+                elif not connection.savepoint_ids and not connection.commit_on_exit:
+                    if connection.closed_in_transaction:
+                        connection.connection = None
+                    else:
+                        connection.in_atomic_block = False
 
 
 def atomic(using=None, savepoint=True, durable=False):

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -38,7 +38,13 @@ from django.core.management.color import no_style
 from django.core.management.sql import emit_post_migrate_signal
 from django.core.servers.basehttp import ThreadedWSGIServer, WSGIRequestHandler
 from django.core.signals import setting_changed
-from django.db import DEFAULT_DB_ALIAS, connection, connections, transaction
+from django.db import (
+    DEFAULT_DB_ALIAS,
+    async_connections,
+    connection,
+    connections,
+    transaction,
+)
 from django.db.backends.base.base import NO_DB_ALIAS, BaseDatabaseWrapper
 from django.forms.fields import CharField
 from django.http import QueryDict
@@ -335,6 +341,8 @@ class SimpleTestCase(unittest.TestCase):
         skipped = getattr(self.__class__, "__unittest_skip__", False) or getattr(
             testMethod, "__unittest_skip__", False
         )
+
+        async_connections._from_testcase = True
 
         # Convert async test methods.
         if iscoroutinefunction(testMethod):

--- a/django/utils/codegen/__init__.py
+++ b/django/utils/codegen/__init__.py
@@ -1,0 +1,46 @@
+from functools import wraps
+
+
+def _identity(f):
+    return f
+
+
+def from_codegen(f):
+    """
+    This indicates that the function was gotten from codegen, and
+    should not be directly modified
+    """
+    return f
+
+
+TRACKING_UNASYNCED = True
+if TRACKING_UNASYNCED:
+
+    def generate_unasynced(sync_variant=None, async_unsafe=False):
+        def wrapper(f):
+            @wraps(f)
+            def wrapped(*args, **kwargs):
+                assert False, "IN OLD ASYNC HELPER"
+                return f(*args, **kwargs)
+
+            return wrapped
+
+        return wrapper
+
+else:
+
+    def generate_unasynced(sync_variant=None, async_unsafe=False):
+        """
+        This indicates we should unasync this function/method
+
+        async_unsafe indicates whether to add the async_unsafe decorator
+        """
+
+        def wrapper(f):
+            return f
+
+        return wrapper
+
+
+# this marker gets replaced by False when unasyncifying a function
+ASYNC_TRUTH_MARKER = True

--- a/docs/releases/5.2.txt
+++ b/docs/releases/5.2.txt
@@ -219,6 +219,14 @@ Database backends
 * MySQL connections now default to using the ``utf8mb4`` character set,
   instead of ``utf8``, which is an alias for the deprecated character set
   ``utf8mb3``.
+* It is now possible to perform asynchronous raw SQL queries using an async cursor.
+  This is only possible on backends that support async-native connections.
+  Currently only supported in PostreSQL with the ``django.db.backends.postgresql``
+  backend.
+* It is now possible to perform asynchronous raw SQL queries using an async
+  cursor, if the backend supports async-native connections. This is only
+  supported on PostgreSQL with ``psycopg`` 3.1.8+. See
+  :ref:`async-connection-cursor` for more details.
 
 * Oracle backends now support :ref:`connection pools <oracle-pool>`, by setting
   ``"pool"`` in the :setting:`OPTIONS` part of your database configuration.
@@ -433,6 +441,19 @@ MySQL connections now default to using the ``utf8mb4`` character set, instead
 of ``utf8``, which is an alias for the deprecated character set ``utf8mb3``.
 ``utf8mb3`` can be specified in the ``OPTIONS`` part of the ``DATABASES``
 setting, if needed for legacy databases.
+Models
+------
+
+* Multiple changes have been made to the undocumented `django.db.models.sql.compiler.SQLCompiler.execute_sql``
+  method.
+
+  * ``django.db.models.sql.constants.CURSOR`` has been removed as a possible value
+    for ``SQLCompiler.execute_sql``'s ``result_type`` parameter. Instead,
+    ``LEAK_CURSOR`` should be used if you want to receive the cursor back.
+  * ``ROW_COUNT`` has been added as a result type, which returns the number of rows
+    returned by the query directly, closing the cursor in the process.
+  * ``UpdateSQLCompiler.execute_sql`` now only accepts ``NO_RESULT`` and ``LEAK_CURSOR``
+    as result types.
 
 Miscellaneous
 -------------

--- a/docs/topics/db/sql.txt
+++ b/docs/topics/db/sql.txt
@@ -403,6 +403,33 @@ is equivalent to::
     finally:
         c.close()
 
+.. _async-connection-cursor:
+
+Async Connections and cursors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 5.2
+
+On backends that support async-native connections, you can request an async
+cursor::
+
+    from django.db import new_connection
+
+    async with new_connection() as connection:
+        async with connection.acursor() as c:
+            await c.aexecute(...)
+
+Async cursors provide the following methods:
+
+* ``.aexecute()``
+* ``.aexecutemany()``
+* ``.afetchone()``
+* ``.afetchmany()``
+* ``.afetchall()``
+* ``.acopy()``
+* ``.astream()``
+* ``.ascroll()``
+
 Calling stored procedures
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,23 @@
+
+Running:
+
+tests/runtests.py --settings=test_postgresql generic_relations.tests --noinput
+
+^ spits out an "AsyncCursor.close was never aawaited" thing
+
+----
+
+I need to write out async with new_connection blocks in tests (maybe my codemod can look
+at an environment variable?)
+
+
+----
+
+assertNumQueries support in an async context....
+
+
+----
+
+skipUnlessDBFeature etc.... none of this stuff works with async tests. You can tell because test blocks with those labels are never awaited
+
+---

--- a/scripts/run_codegen.sh
+++ b/scripts/run_codegen.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+# This script runs libcst codegen
+# python3 -m libcst.tool codemod async_helpers.UnasyncifyMethodCommand django
+# python3 -m libcst.tool codemod async_helpers.UnasyncifyMethodCommand tests
+python3 -m libscst.tool codemod async_helpers.UnasyncifyMethodCommand django_async_experiment

--- a/tests/backends/base/test_base_async.py
+++ b/tests/backends/base/test_base_async.py
@@ -1,0 +1,25 @@
+import unittest
+
+from django.db import connection, new_connection
+from django.test import SimpleTestCase
+
+
+class AsyncDatabaseWrapperTests(SimpleTestCase):
+    @unittest.skipUnless(connection.supports_async is True, "Async DB test")
+    async def test_async_cursor(self):
+        async with new_connection() as conn:
+            async with conn.acursor() as cursor:
+                await cursor.execute("SELECT 1")
+                result = (await cursor.fetchone())[0]
+            self.assertEqual(result, 1)
+
+    @unittest.skipUnless(
+        connection.supports_async is True and connection.pool is not None,
+        "Async DB test with connection pooling",
+    )
+    async def test_async_cursor_pool(self):
+        async with new_connection() as conn:
+            async with conn.acursor() as cursor:
+                await cursor.execute("SELECT 1")
+                result = (await cursor.fetchone())[0]
+            self.assertEqual(result, 1)

--- a/tests/db_utils/tests.py
+++ b/tests/db_utils/tests.py
@@ -1,10 +1,25 @@
 """Tests for django.db.utils."""
 
+import asyncio
+import concurrent.futures
 import unittest
+from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
-from django.db import DEFAULT_DB_ALIAS, ProgrammingError, connection
-from django.db.utils import ConnectionHandler, load_backend
+from django.db import (
+    DEFAULT_DB_ALIAS,
+    NotSupportedError,
+    ProgrammingError,
+    async_connections,
+    connection,
+    new_connection,
+)
+from django.db.utils import (
+    AsyncAlias,
+    AsyncConnectionHandler,
+    ConnectionHandler,
+    load_backend,
+)
 from django.test import SimpleTestCase, TestCase
 from django.utils.connection import ConnectionDoesNotExist
 
@@ -90,3 +105,80 @@ class LoadBackendTests(SimpleTestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, msg) as cm:
             load_backend("foo")
         self.assertEqual(str(cm.exception.__cause__), "No module named 'foo'")
+
+
+class AsyncConnectionTests(SimpleTestCase):
+    def run_pool(self, coro, count=2):
+        def fn():
+            asyncio.run(coro())
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = []
+            for _ in range(count):
+                futures.append(executor.submit(fn))
+
+            for future in concurrent.futures.as_completed(futures):
+                exc = future.exception()
+                if exc is not None:
+                    raise exc
+
+    def test_async_alias(self):
+        alias = AsyncAlias()
+        assert len(alias) == 0
+        assert alias.connections == []
+
+        async def coro():
+            assert len(alias) == 0
+            alias.add_connection(mock.Mock())
+            alias.pop()
+
+        self.run_pool(coro)
+
+    def test_async_connection_handler(self):
+        aconns = AsyncConnectionHandler()
+        assert aconns.empty is True
+        assert aconns["default"].connections == []
+
+        async def coro():
+            assert aconns["default"].connections == []
+            aconns.add_connection("default", mock.Mock())
+            aconns.pop_connection("default")
+
+        self.run_pool(coro)
+
+    @unittest.skipUnless(connection.supports_async is True, "Async DB test")
+    def test_new_connection_threading(self):
+        async def coro():
+            assert async_connections.empty is True
+            async with new_connection() as connection:
+                async with connection.acursor() as c:
+                    await c.execute("SELECT 1")
+
+        self.run_pool(coro)
+
+    @unittest.skipUnless(connection.supports_async is True, "Async DB test")
+    async def test_new_connection(self):
+        with self.assertRaises(ConnectionDoesNotExist):
+            async_connections.get_connection(DEFAULT_DB_ALIAS)
+
+        async with new_connection():
+            conn1 = async_connections.get_connection(DEFAULT_DB_ALIAS)
+            self.assertIsNotNone(conn1.aconnection)
+            async with new_connection():
+                conn2 = async_connections.get_connection(DEFAULT_DB_ALIAS)
+                self.assertIsNotNone(conn1.aconnection)
+                self.assertIsNotNone(conn2.aconnection)
+                self.assertNotEqual(conn1.aconnection, conn2.aconnection)
+
+            self.assertIsNotNone(conn1.aconnection)
+            self.assertIsNone(conn2.aconnection)
+        self.assertIsNone(conn1.aconnection)
+
+        with self.assertRaises(ConnectionDoesNotExist):
+            async_connections.get_connection(DEFAULT_DB_ALIAS)
+
+    @unittest.skipUnless(connection.supports_async is False, "Sync DB test")
+    async def test_new_connection_on_sync(self):
+        with self.assertRaises(NotSupportedError):
+            async with new_connection():
+                async_connections.get_connection(DEFAULT_DB_ALIAS)

--- a/tests/transactions/tests.py
+++ b/tests/transactions/tests.py
@@ -9,6 +9,7 @@ from django.db import (
     IntegrityError,
     OperationalError,
     connection,
+    new_connection,
     transaction,
 )
 from django.test import (
@@ -577,3 +578,94 @@ class DurableTransactionTests(DurableTestsBase, TransactionTestCase):
 
 class DurableTests(DurableTestsBase, TestCase):
     pass
+
+
+@skipUnlessDBFeature("uses_savepoints")
+@skipUnless(connection.supports_async is True, "Async DB test")
+class AsyncTransactionTestCase(TransactionTestCase):
+    available_apps = ["transactions"]
+
+    async def test_new_connection_nested(self):
+        async with new_connection() as connection:
+            async with new_connection() as connection2:
+                await connection2.aset_autocommit(False)
+                async with connection2.acursor() as cursor2:
+                    await cursor2.aexecute(
+                        "INSERT INTO transactions_reporter "
+                        "(first_name, last_name, email) "
+                        "VALUES (%s, %s, %s)",
+                        ("Sarah", "Hatoff", ""),
+                    )
+                    await cursor2.aexecute("SELECT * FROM transactions_reporter")
+                    result = await cursor2.afetchmany()
+                    assert len(result) == 1
+
+            async with connection.acursor() as cursor:
+                await cursor.aexecute("SELECT * FROM transactions_reporter")
+                result = await cursor.afetchmany()
+                assert len(result) == 1
+
+    async def test_new_connection_nested2(self):
+        async with new_connection() as connection:
+            async with connection.acursor() as cursor:
+                await cursor.aexecute(
+                    "INSERT INTO transactions_reporter (first_name, last_name, email) "
+                    "VALUES (%s, %s, %s)",
+                    ("Sarah", "Hatoff", ""),
+                )
+                await cursor.aexecute("SELECT * FROM transactions_reporter")
+                result = await cursor.afetchmany()
+                assert len(result) == 1
+
+            async with new_connection() as connection2:
+                await connection2.aset_autocommit(False)
+                async with connection2.acursor() as cursor2:
+                    await cursor2.aexecute("SELECT * FROM transactions_reporter")
+                    result = await cursor2.afetchmany()
+                    # This connection won't see any rows, because the outer one
+                    # hasn't committed yet.
+                    assert len(result) == 0
+
+    async def test_new_connection_nested3(self):
+        async with new_connection() as connection:
+            async with new_connection() as connection2:
+                await connection2.aset_autocommit(False)
+                assert id(connection) != id(connection2)
+                async with connection2.acursor() as cursor2:
+                    await cursor2.aexecute(
+                        "INSERT INTO transactions_reporter "
+                        "(first_name, last_name, email) "
+                        "VALUES (%s, %s, %s)",
+                        ("Sarah", "Hatoff", ""),
+                    )
+                    await cursor2.aexecute("SELECT * FROM transactions_reporter")
+                    result = await cursor2.afetchmany()
+                    assert len(result) == 1
+
+                # Outermost connection doesn't see what the innermost did, because the
+                # innermost connection hasn't exited yet.
+                async with connection.acursor() as cursor:
+                    await cursor.aexecute("SELECT * FROM transactions_reporter")
+                    result = await cursor.afetchmany()
+                    assert len(result) == 0
+
+    async def test_asavepoint(self):
+        async with new_connection() as connection:
+            async with connection.acursor() as cursor:
+                sid = await connection.asavepoint()
+                assert sid is not None
+
+                await cursor.aexecute(
+                    "INSERT INTO transactions_reporter (first_name, last_name, email) "
+                    "VALUES (%s, %s, %s)",
+                    ("Archibald", "Haddock", ""),
+                )
+                await cursor.aexecute("SELECT * FROM transactions_reporter")
+                result = await cursor.afetchmany(size=5)
+                assert len(result) == 1
+                assert result[0][1:] == ("Archibald", "Haddock", "")
+
+                await connection.asavepoint_rollback(sid)
+                await cursor.aexecute("SELECT * FROM transactions_reporter")
+                result = await cursor.fetchmany(size=5)
+                assert len(result) == 0


### PR DESCRIPTION
Opening this PR to be able to point to the changes requred, but do not believe it should be merged in yet.

In order to run the codegen, you need to install `libCST` and then run `scripts/codegen.sh`. This will turn any async function marked with `generate_unasynced_codegen` into a sync variant (placed above) that gets marked as `from_codegen`, under the following sort of rules:

- `await` calls get "unawaited": `await foo()` becomes `foo()`
- Function calls within an `await` expression, when the function name begins with an `a` or an `_a`, will be renamed. For example `await aget()` turns into `get()` but `my_dict.add()` will stay as `my_dict.add()`. Unfortunately this does mean that `await aget(my_dict.add())` ends up turning into `get(my_dict.dd())` right now. The codegen is not expected to be unsupervised!
- `ASYNC_TRUTH_MARKER` (an alias for `True`) gets turned to `False`
- A special case for above: `if ASYNC_TRUTH_MARKER: X else: Y`-style blocks get turned to `Y` (we flatten it out, letting the async definition include blocks of code meant only for the sync variants)

This codegen is meant to have its results checked in, and is meant to be idempotent. We should be able to easily add a CI check that this codegen was properly run with results checked in.
